### PR TITLE
Updated PG UI to redirect users to logical page

### DIFF
--- a/app/pods/app/parenting-group/conversations/new/template.hbs
+++ b/app/pods/app/parenting-group/conversations/new/template.hbs
@@ -20,10 +20,3 @@
   </div>
 </div>
 
-<h3> New Conversation </h3>
-<div class='input-group'>
-  <label>Name</label>
-  {{input value=model.name}}
-</div>
-<button {{action 'save' model}}>Create Conversation</button>
-{{outlet}}

--- a/app/pods/app/parenting-groups/route.js
+++ b/app/pods/app/parenting-groups/route.js
@@ -29,7 +29,12 @@ export default Ember.Route.extend({
     },
 
     goToPg: function(pg) {
-      this.transitionTo("app.parenting-group", pg);
+      let firstConversation = pg.get('conversations.firstObject.id');
+      if (firstConversation === undefined) {
+        this.transitionTo("app.parenting-group.conversations.new", pg)
+      } else {
+        this.transitionTo("app.parenting-group.conversation.messages", pg, firstConversation)
+      }
     },
 
     goToPgInvite: function(pg) {


### PR DESCRIPTION
This PR updates the parentGroup UI to redirect users to logical page. For example, is PG doesn't have any existing conversations it redirects to the new conversation path. If a user does have existing conversations the user is redirected to the first conversation in the parenting group.